### PR TITLE
Set target to 'ES5', use lib 'es2015' and 'dom'. Fixes IE11 class issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "lib": ["es2015", "dom"],                 /* List of library files to be included in the compilation. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */


### PR DESCRIPTION
With only target set to `ES2015` the code does not transpile the `class` keyword. Causing a Syntax Error in IE11.

This small PR changes the target to `ES5` and adds the libs to keep the project functioning.

Pre change `dist/plugin.js`:
```
...
const mixin_1 = require("./mixin");
exports.msalMixin = mixin_1.mixin;
class msalPlugin {
    static install(Vue, options) {
        Vue.prototype.$msal = new msalPlugin(options, Vue);
    }
    constructor(options, Vue = undefined) {
        const msal = new main_1.MSAL(options);
        if (Vue && options.framework && options.framework.globalMixin) {
            Vue.mixin(mixin_1.mixin);
        }
...
```

Post change `dist/plugin.js`:
```
...
var main_1 = require("./src/main");
var mixin_1 = require("./mixin");
exports.msalMixin = mixin_1.mixin;
var msalPlugin = /** @class */ (function () {
    function msalPlugin(options, Vue) {
        if (Vue === void 0) { Vue = undefined; }
        var msal = new main_1.MSAL(options);
        if (Vue && options.framework && options.framework.globalMixin) {
            Vue.mixin(mixin_1.mixin);
        }
...
```

Thank you for your considerations and hope we can get IE11 compatibility again :)