### PR TITLE
bumped msal version to include increasing header size fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "lodash": "^4.17.15",
-    "msal": "^1.3.2"
+    "msal": "^1.3.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.138"


### PR DESCRIPTION
msal version 1.3.3 introduced a bugfix to prevent headers from growing uncontrolled in size:
https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/1188