### PR TITLE
Update msal dependency to include patch which reduces cookie lengths.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,90 @@
 {
   "name": "vue-msal",
   "version": "3.2.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.19.0",
+        "lodash": "^4.17.15",
+        "msal": "^1.3.3"
+      },
+      "devDependencies": {
+        "@types/lodash": "^4.14.138"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.138",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
+      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dependencies": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/msal": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.3.tgz",
+      "integrity": "sha512-1gscQA6OZ4EMvIw3PdkE9GECOcqGZkA8JOOHP5HqGlhmUvFkz64FTtu0Z71iuyt803Z1PwGnvE0w2bETd9u59w==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    }
+  },
   "dependencies": {
     "@types/lodash": {
       "version": "4.14.138",
@@ -51,9 +133,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "msal": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.2.tgz",
-      "integrity": "sha512-vhcpM/ELL+UI7i4HzCegcbSfPMLqf3kp8mAT840bK1ZaDcb7Z1mOJik1jg202V0yfnh/bBPxZhQP6xFgD9g5eA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.3.3.tgz",
+      "integrity": "sha512-1gscQA6OZ4EMvIw3PdkE9GECOcqGZkA8JOOHP5HqGlhmUvFkz64FTtu0Z71iuyt803Z1PwGnvE0w2bETd9u59w==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "lodash": "^4.17.15",
-    "msal": "^1.3.2"
+    "msal": "^1.3.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.138"


### PR DESCRIPTION
This change should resolve overly long cookies causing the server to return an error.

https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/1188