### PR TITLE
Fix "onToken" not called if no idToken found in cache

### DIFF
--- a/lib/src/main.ts
+++ b/lib/src/main.ts
@@ -151,7 +151,7 @@ export class MSAL implements MSALBasic {
             this.setToken('accessToken', response.accessToken, response.expiresOn, response.scopes);
             setCallback = true;
         }
-        if(this.data.idToken !== response.idToken.rawIdToken) {
+        if(response.idToken && this.data.idToken !== response.idToken.rawIdToken) {
             this.setToken('idToken', response.idToken.rawIdToken, new Date(response.idToken.expiration * 1000), [this.auth.clientId]);
             setCallback = true;
         }


### PR DESCRIPTION
This fixes an issue where "onToken" is not called at all due to an error when trying to access `response.idToken.rawidToken` if no idToken was delivered in the response - in our case from the cache.